### PR TITLE
fix: remove syntax to have filters for inserts

### DIFF
--- a/markup/blocks/inserts/README.md
+++ b/markup/blocks/inserts/README.md
@@ -14,7 +14,7 @@ There are two different kinds of block inserts:
    This refers to resources that cannot be converted to Unimarkup content.
    Examples are images, videos, audio, etc.
 
-   Because the resource is not integrated into the Unimarkup document, it must be assured by the user that the resource is available at the set location.
+   **Note:** Because the resource may not be integrated into the Unimarkup document, it must be assured by the user that the resource is available at the set location.
 
    The [block media insert](/markup/blocks/inserts/media-block-insert.md) element may be used to insert media resources as block content.
 

--- a/markup/blocks/inserts/README.md
+++ b/markup/blocks/inserts/README.md
@@ -14,23 +14,13 @@ There are two different kinds of block inserts:
    This refers to resources that cannot be converted to Unimarkup content.
    Examples are images, videos, audio, etc.
 
-   Since the resource is not integrated into the Unimarkup document, it must be assured by the user that the resource is available at the set location.
+   Because the resource is not integrated into the Unimarkup document, it must be assured by the user that the resource is available at the set location.
 
    The [block media insert](/markup/blocks/inserts/media-block-insert.md) element may be used to insert media resources as block content.
 
 2. Convertible resources
 
    This refers to resources that may be converted to Unimarkup content.
-   
-   If the resource type is supported by the Unimarkup implementation, the content must be integrated into the Unimarkup document using regular Unimarkup block elements.
-   Since the content is integrated into the Unimarkup document, the resource must only be available for rendering.
-
-   Since the resource must be convertible to Unimarkup, there must be an understanding of a Unimarkup ID in the content of the resource.
-   One or more Unimarkup IDs may then be used as **filter attribute** `insert-ids` for inserts, to only get the content of the elements identified by the given IDs.
-
-   **Note:** Multiple IDs must be separated by whitespace.
-
-   **Note:** The order of inserted elements must follow the document flow of the external resource.
 
    There are two elements for block inserts of convertible resources:
 
@@ -38,7 +28,7 @@ There are two different kinds of block inserts:
 
       This block element tries to interpret the given content and convert it to fitting Unimarkup block elements.
 
-      **Note:** If conversion to block elements is not possible, the alternative text must be used instead. In this case, the implementation should set a warning if the link was not empty.
+      **Note:** If conversion to block elements is not possible, the alternative text must be used instead. In this case, the implementation should set a warning.
 
    2. [block verbatim insert](/markup/blocks/inserts/verbatim-block-insert.md)
 

--- a/markup/blocks/inserts/render-block-insert.md
+++ b/markup/blocks/inserts/render-block-insert.md
@@ -5,19 +5,18 @@ The general syntax for the render block insert is described in the general [bloc
 The keyword for render inserts is `''`.
 
 This insert tries to convert the resource content into Unimarkup block elements.
-Parameters may be set after the URL, to use them for the content conversion.
-Multiple parameters must be separated by `,`.
+Parameters may be set after the URL, using the attribute syntax.
 
-**Note:** Parameters for inserts of Unimarkup files map to the ones defined in the configuration of the inserted file.
+**Note:** Parameters for inserts of Unimarkup files map to the ones defined in the preamble of the inserted file.
 
 **Usage:**
 
 ```
 ''[<alternative text for the file content that is inserted>](<url>)
 
-''[First and second heading](SomeUnimarkupContent.um){ insert-ids : "first-heading" "sec-heading" }
+''[File content of `SomeUnimarkupContent.um` is inserted at this position](SomeUnimarkupContent.um)
 
-''[Insert with parameters](unimarkup-file.um param1 := 2, param2 := 10)
+''[Insert with parameters](unimarkup-file.um {param1 : 2; param2 : 10})
 ```
 
 **Type:** `render-block-insert`
@@ -36,6 +35,10 @@ Multiple parameters must be separated by `,`.
   
   **Note:** If the renderer is not supported by the implementation, the content must be treated as plain text.
 
+  **Note:** Implementations may not offer this attribute if they only support one renderer.
+
 - `sandbox` ... Set to `true` to exclude elements like headings from being added to the document section.
+
+  **Note:** Implementations are free to define further rules that apply for this attribute.
 
 **Note:** Implementations may allow additional attributes.

--- a/markup/blocks/inserts/verbatim-block-insert.md
+++ b/markup/blocks/inserts/verbatim-block-insert.md
@@ -12,7 +12,7 @@ The content itself is treated as plain text, with optional syntax highlighting a
 ```
 ``[<alternative description for the file content that is inserted>](<file path>)
 
-``[First and second heading](UnimarkupContent.um){ insert-ids : "first-heading" "sec-heading" }
+``[Content converted to one verbatim block](UnimarkupContent.um)
 ```
 
 **Type:** `verbatim-block-insert`
@@ -30,5 +30,7 @@ The content itself is treated as plain text, with optional syntax highlighting a
   **Note:** The supported highlighters depend on the used implementation.
   
   **Note:** If the highlighter is not supported by the implementation, the content must be treated as plain text.
+
+  **Note:** Implementations may not offer this attribute if they only support one highlighter.
 
 **Note:** Implementations may allow additional attributes.

--- a/markup/inlines/boxes/inserts/README.md
+++ b/markup/inlines/boxes/inserts/README.md
@@ -21,12 +21,6 @@ There are two different kinds of inline inserts:
 2. Convertible resources
 
    This refers to resources that may be converted to Unimarkup content.
-   
-   If the resource type is supported by the Unimarkup implementation, the content must be integrated into the Unimarkup document using regular Unimarkup inline elements.
-   Since the content is integrated into the Unimarkup document, the resource must only be available for rendering.
-
-   Since the resource must be convertible to Unimarkup, there must be an understanding of a Unimarkup ID in the content of the resource.
-   This ID may then be used as **filter attribute** `insert-id` for inserts, to only get the content of the element identified by this ID.
 
    There are two elements for inline inserts of convertible resources:
 
@@ -34,7 +28,7 @@ There are two different kinds of inline inserts:
 
       This inline element tries to interpret the given content and convert it to fitting Unimarkup inline elements.
 
-      **Note:** If conversion to inline elements is not possible, the alternative text must be used instead. In this case, the implementation should set a warning if the link was not empty.
+      **Note:** If conversion to inline elements is not possible, the alternative text must be used instead. In this case, the implementation should set a warning.
 
       **Note:** Using an empty link is a short way to get rendered inline content, since there is no render formatting.
 
@@ -42,4 +36,4 @@ There are two different kinds of inline inserts:
 
       This inline element applies verbatim formatting to the content.
 
-      **Note:** If the content contains a blank line, the alternative text must be used instead. In this case, the implementation should set a warning if the link was not empty.
+      **Note:** If the content contains a blank line, the alternative text must be used instead. In this case, the implementation should set a warning.

--- a/markup/inlines/boxes/inserts/README.md
+++ b/markup/inlines/boxes/inserts/README.md
@@ -14,7 +14,7 @@ There are two different kinds of inline inserts:
    This refers to resources that cannot be converted to Unimarkup content.
    Examples are images, videos, audio, etc.
 
-   Since the resource is not integrated into the Unimarkup document, it must be assured by the user that the resource is available at the set location.
+   **Note:** Because the resource may not be integrated into the Unimarkup document, it must be assured by the user that the resource is available at the set location.
 
    The [inline media insert](/markup/inlines/boxes/inserts/inline-media-insert.md) element may be used to insert media resources as inline content.
 

--- a/markup/inlines/boxes/inserts/inline-render-insert.md
+++ b/markup/inlines/boxes/inserts/inline-render-insert.md
@@ -5,19 +5,20 @@ The general syntax for the inline render insert is described in the general [inl
 The keyword for render inserts is `''`.
 
 This insert tries to convert the resource content into Unimarkup inline elements.
-Parameters may be set after the URL, to use them for the content conversion.
-Multiple parameters must be separated by `,`.
+Parameters may be set after the URL, using the attribute syntax.
 
-**Note:** Parameters for inserts of Unimarkup files map to the ones defined in the configuration of the inserted file.
+**Note:** Parameters for inserts of Unimarkup files map to the ones defined in the preamble of the inserted file.
+
+**Note:** Because inline elements cannot contain blank lines, an inserted Unimarkup file must only contain one paragraph element after the preamble.
 
 **Usage:**
 
 ```
 [''<alternative text for the file content that is inserted>](<url>)
 
-[''First heading](SomeUnimarkupContent.um){ insert-id : "first-heading" }
+[''File content of `SomeUnimarkupCintent.um` rendered at this position as inline elements](SomeUnimarkupContent.um)
 
-[''Insert with parameters](unimarkup-file.um param1 := 2, param2 := 10)
+[''Insert with parameters](unimarkup-file.um { param1 : 2; param2 : 10})
 ```
 
 **Type:** `inline-render-insert`
@@ -36,6 +37,10 @@ Multiple parameters must be separated by `,`.
   
   **Note:** If the renderer is not supported by the implementation, the content must be treated as plain text.
 
+  **Note:** Implementations may not offer this attribute if they only support one renderer.
+
 - `sandbox` ... Set to `true` to exclude elements like headings from being added to the document section.
+
+  **Note:** Implementations are free to define further rules that apply for this attribute.
 
 **Note:** Implementations may allow additional attributes.

--- a/markup/inlines/boxes/inserts/inline-verbatim-insert.md
+++ b/markup/inlines/boxes/inserts/inline-verbatim-insert.md
@@ -12,7 +12,7 @@ The content itself is treated as plain text, with optional syntax highlighting a
 ```
 [``<alternative description for the file content that is inserted>](<file path>)
 
-Some paragraph text with [``First heading](UnimarkupContent.um){ insert-id : "first-heading" }.
+Some paragraph text with [``content from `UnimarkupContent.um`](UnimarkupContent.um).
 ```
 
 **Type:** `inline-verbatim-insert`
@@ -30,5 +30,7 @@ Some paragraph text with [``First heading](UnimarkupContent.um){ insert-id : "fi
   **Note:** The supported highlighters depend on the used implementation.
   
   **Note:** If the highlighter is not supported by the implementation, the content must be treated as plain text.
+
+  **Note:** Implementations may not offer this attribute if they only support one highlighter.
 
 **Note:** Implementations may allow additional attributes.


### PR DESCRIPTION
closes #30 

This PR removes the option to have filters for file inserts.