### PR TITLE
fix: define implicit element endings

### DIFF
--- a/markup/blocks/enclosed/README.md
+++ b/markup/blocks/enclosed/README.md
@@ -8,17 +8,23 @@ Both start and end keywords must have the same length, with a minimum keyword le
 The block content may then start at the beginning of the line after the start keyword.
 The start and end keyword lines count as blank lines for inner block elements.
 
-To nest enclosed blocks that allow nesting, the inner keywords must be at least one grapheme longer than the outer ones for blocks having the same keyword for start and end.
+To nest enclosed blocks that allow nesting, the inner keyword length must differ from the outer ones by at least one grapheme for blocks having the same keyword for start and end.
 Blocks with different keywords for start and end may be nested with the same keyword length for outer and inner blocks.
-Increasing the inner length makes it easier to add nested blocks, because the outer keywords must not be changed.
 
-Attributes may be set directly after the end keyword without any whitespace between.
+**Note:** Increasing the inner length makes it easier to add nested blocks, because the outer keywords must not be changed.
 
-An enclosed block must be taken as plain text paragraph, if the end keyword is not found at the end of input, or if the outer block in a nested or indented context closes.
+An enclosed block is implicitly closed if an outer block end or EOI is reached before the enclosed block reaches its end keywords.
+In this case, no attributes can be set, because the end keywords are missing.
+An enclosed block must be taken as plain text paragraph if it is not followed by a blank line.
+Implementations may relax the requirement for blank lines after an enclosed block in case
+attributes or decorators are set after the ending keywords to prevent expensive rollback during parsing. 
+
+Attributes or block decoration may be set directly after the end keyword without any whitespace between.
+Those decorators may again be implicitly closed if an outer block end or EOI is reached before the decorators reach their end keywords.
 
 **Example:**
 
-```
+````
 [[[
 A paragraph that has red text color.
 
@@ -26,6 +32,11 @@ This paragraph also has red text color.
 ]]]{
     color: red;
 }
-```
+
+- list entry
+
+    ```
+    implicitly closed verbatim block
+````
 
 **Type:** All enclosed block elements are subtypes of the `enclosed-block` type.

--- a/markup/blocks/inserts/README.md
+++ b/markup/blocks/inserts/README.md
@@ -3,7 +3,11 @@
 Block inserts may be used to integrate external resources into a Unimarkup file.
 The general form for block inserts looks like a hyperlink with a **keyword** set directly before `[`.
 
-**Note:** The description given inside `[]` is used as alternative text, if the external resource could not be inserted or displayed. The text may then be used as fallback content for convertible resources, or plain text for media resources.
+A block insert is implicitly closed if an outer block end or EOI is reached before the block insert reaches its end.
+In this case, no attributes can be set, because the end keywords are missing.
+
+**Note:** The description given inside `[]` is used as alternative text, if the external resource could not be inserted or displayed.
+The text may then be used as fallback content for convertible resources, or plain text for media resources.
 
 **Type:** All block inserts are subtypes of the `block-insert` type.
 

--- a/markup/decorators/README.md
+++ b/markup/decorators/README.md
@@ -2,3 +2,4 @@
 
 This section contains file and element decorators.
 
+A decorator is implicitly closed if an outer block end or EOI is reached before the decorator reaches its end.

--- a/markup/element-ids.md
+++ b/markup/element-ids.md
@@ -2,7 +2,7 @@
 
 **WIP**
 
-**Note:** The ID may not contain `#`, `.`, `+`, `"`, `` ` ``, or any whitespace.
+**Note:** The ID may not contain `#`, `.`, `+`, `"`, `` ` ``, `'`, or any whitespace.
 
 ## Manually set IDs
 
@@ -13,36 +13,7 @@ The implementation should set a warning if this convention is not fulfilled.
 
 ## Automatically generated IDs
 
-Element IDs for elements **except** headings and logic elements may be generated automatically by an implementation, but must follow the `<namespace>_<element-type>-<element count of same type from file start>` convention.
+Element IDs for elements **except** headings and logic elements may be generated automatically by an implementation, but must follow the `<namespace>_<element id>` convention.
 
 The generation of heading IDs is defined in the [heading](/markup/blocks/heading.md) section.
-
-Logic elements do not have an ID, but are referred to by their name.
-However, an implementation may choose to set IDs for logic elements.
-This might be useful for the `id` column of the [´.umi` i18n format](/i18n/intermediate-formats/umi/README.md).
-
-**Example:**
-
-The example assumes `namespace = root`
-
-```
-- Bullet list entry 1
-
-  Some paragraph in entry 1.
-
-- Bullet list entry 2
-
-  Some paragraph in entry 2.
-```
-
-The above is equivalent to the following manually set IDs:
-
-```
-- Bullet list entry 1 { id: "root_bullet-list-entry-1"}
-
-  Some paragraph in entry 1.{ id: "root_paragraph-1"}
-
-- Bullet list entry 2 { id: "root_bullet-list-entry-2"}
-
-  Some paragraph in entry 2.{ id: "root_paragraph-2"}
-```
+The name of logic elements is used as their ID.

--- a/markup/inlines/explicit-substitutions/named-substitution.md
+++ b/markup/inlines/explicit-substitutions/named-substitution.md
@@ -4,12 +4,12 @@
 
 Named substitution may be used to replace a word by inline content.
 For this, the word to be substituted must be enclosed by `::`.
+Substitutions are only possible for words. Therefore, whitespace is not allowed as part of the name to substitute.
 
-**Note:** If whitespaces appear between `::` (more than one word between),
-no substitution is applied. Therefore, substitutions are only possible per word.
+Named substitutions are not implicitly closed, to prevent collision with abbreviations.
 
 [Emoji aliases](https://github.com/github/gemoji/blob/master/db/emoji.json)
-must be predefined for substitution, substituting the alias with the respective Unicode code point.
+must be predefined for substitution, substituting the alias with the respective Unicode grapheme.
 
 To define new named substitutions, set `:` after the word to substitute, followed by the text that is used as substitution.
 


### PR DESCRIPTION
## List of issues that this PR closes

closes #52 

## Relevant decisions you made in this PR

Enclosed elements may now be closed implicitly,
except named substitutions.
Abbreviations and implicitly closed named substitutions would otherwise be too similar.
